### PR TITLE
[BE-32] Feat: 돌봄할 아이 타입 찾기 API

### DIFF
--- a/src/apis/childTypes/childType.controller.ts
+++ b/src/apis/childTypes/childType.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { ChildTypeService } from './childType.service';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CreateChildTypeDto } from './dto/createChildType.dto';

--- a/src/apis/childTypes/childType.controller.ts
+++ b/src/apis/childTypes/childType.controller.ts
@@ -1,12 +1,28 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { ChildTypeService } from './childType.service';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CreateChildTypeDto } from './dto/createChildType.dto';
-import { CreateChildTypeReturn } from './interfaces/childTypes.interface';
+import {
+  CreateChildTypeReturn,
+  FetchChildTypeReturn,
+} from './interfaces/childTypes.interface';
 
 @Controller('childType')
 export class ChildTypeController {
   constructor(private childTypeService: ChildTypeService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: '아이 타입 조회 API',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '조회 성공',
+    type: [FetchChildTypeReturn],
+  })
+  fetchChildType(): Promise<FetchChildTypeReturn[]> {
+    return this.childTypeService.findAllByName();
+  }
 
   @Post()
   @ApiOperation({

--- a/src/apis/childTypes/childType.service.ts
+++ b/src/apis/childTypes/childType.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { ChildType } from './entities/childType.entity';
 import { Repository } from 'typeorm';
 import { CreateChildTypeDto } from './dto/createChildType.dto';
+import { FetchChildTypeReturn } from './interfaces/childTypes.interface';
 
 @Injectable()
 export class ChildTypeService {
@@ -26,6 +27,10 @@ export class ChildTypeService {
 
     if (childTypeName)
       throw new UnprocessableEntityException('이미 등록된 아이 타입입니다.');
+  }
+
+  async findAllByName(): Promise<FetchChildTypeReturn[]> {
+    return await this.childTypeRepository.find();
   }
 
   async create(createChildTypeDto: CreateChildTypeDto) {

--- a/src/apis/childTypes/interfaces/childTypes.interface.ts
+++ b/src/apis/childTypes/interfaces/childTypes.interface.ts
@@ -5,3 +5,5 @@ export class CreateChildTypeReturn extends PickType(ChildType, [
   'id',
   'name',
 ] as const) {}
+
+export class FetchChildTypeReturn extends CreateChildTypeReturn {}


### PR DESCRIPTION
## What is the current behavior?
<!-- 수정하는 부분에 대한 설명과 (있는 경우) 연관된 이슈를 달아주세요 -->
Issue Number: N/A

## What is the new behavior?
돌봄할 아이 타입 찾기 API를 만들었습니다.

## 기타
시니어시터 유저 생성시, 돌봄할 아이 타입의 Id 값을 넣어주어야 하는데
해당 Id값을 모를때를 방지하여 조회할 수 있는 API를 만들었습니다.
