### PR TITLE
[BE-33] Feat: 부모회원ID 값을 기반으로 내 아이 모두 찾기 API 

### DIFF
--- a/src/apis/children/children.controller.ts
+++ b/src/apis/children/children.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { ChildrenService } from './children.service';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { FetchAllChildrenReturn } from './interfaces/children.interface';
 
 @Controller('children')
 export class ChildrenController {
@@ -14,9 +15,11 @@ export class ChildrenController {
   @ApiResponse({
     status: 200,
     description: '조회 성공',
-    // type:
+    type: [FetchAllChildrenReturn],
   })
-  fetchAllChildren(@Param('parentsUserId') parentsUserId: string) {
+  fetchAllChildren(
+    @Param('parentsUserId') parentsUserId: string
+  ): Promise<FetchAllChildrenReturn[]> {
     return this.childrenService.findAllByParentsUserId({ parentsUserId });
   }
 }

--- a/src/apis/children/children.controller.ts
+++ b/src/apis/children/children.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ChildrenService } from './children.service';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@Controller('children')
+export class ChildrenController {
+  constructor(private childrenService: ChildrenService) {}
+
+  @Get(':parentsUserId')
+  @ApiOperation({
+    summary: '내 아이 전체 조회 API',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '조회 성공',
+    // type:
+  })
+  fetchAllChildren(@Param('parentsUserId') parentsUserId: string) {
+    return this.childrenService.findAllByParentsUserId({ parentsUserId });
+  }
+}

--- a/src/apis/children/children.controller.ts
+++ b/src/apis/children/children.controller.ts
@@ -9,6 +9,7 @@ export class ChildrenController {
   @Get(':parentsUserId')
   @ApiOperation({
     summary: '내 아이 전체 조회 API',
+    description: '생년월일 순으로 조회 됩니다.',
   })
   @ApiResponse({
     status: 200,

--- a/src/apis/children/children.module.ts
+++ b/src/apis/children/children.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ChildrenService } from './children.service';
 import { Children } from './entities/children.entity';
+import { ChildrenController } from './children.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Children])],
   providers: [ChildrenService],
-  controllers: [],
+  controllers: [ChildrenController],
   exports: [ChildrenService],
 })
 export class ChildrenModule {}

--- a/src/apis/children/children.service.ts
+++ b/src/apis/children/children.service.ts
@@ -23,6 +23,8 @@ export class ChildrenService {
     return children;
   }
 
+  async findAllByParentsUserId({ parentsUserId }) {}
+
   async addChildren({
     childrenBirths,
     userId,

--- a/src/apis/children/children.service.ts
+++ b/src/apis/children/children.service.ts
@@ -23,7 +23,18 @@ export class ChildrenService {
     return children;
   }
 
-  async findAllByParentsUserId({ parentsUserId }) {}
+  async findAllByParentsUserId({ parentsUserId }) {
+    return await this.childrenRepository.find({
+      where: {
+        user: {
+          id: parentsUserId,
+        },
+      },
+      order: {
+        birth: 'ASC',
+      },
+    });
+  }
 
   async addChildren({
     childrenBirths,

--- a/src/apis/children/children.service.ts
+++ b/src/apis/children/children.service.ts
@@ -2,7 +2,10 @@ import { Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Children } from './entities/children.entity';
 import { Repository } from 'typeorm';
-import { IChildrenAddChildren } from './interfaces/children.interface';
+import {
+  FetchAllChildrenReturn,
+  IChildrenAddChildren,
+} from './interfaces/children.interface';
 
 @Injectable()
 export class ChildrenService {
@@ -11,7 +14,7 @@ export class ChildrenService {
     private childrenRepository: Repository<Children>
   ) {}
 
-  async findOneById({ childrenId }: { childrenId: string }) {
+  async findOneById({ childrenId }: { childrenId: string }): Promise<Children> {
     const children = await this.childrenRepository.findOne({
       where: { id: childrenId },
       relations: ['user'],
@@ -23,7 +26,11 @@ export class ChildrenService {
     return children;
   }
 
-  async findAllByParentsUserId({ parentsUserId }: { parentsUserId: string }) {
+  async findAllByParentsUserId({
+    parentsUserId,
+  }: {
+    parentsUserId: string;
+  }): Promise<FetchAllChildrenReturn[]> {
     return await this.childrenRepository.find({
       where: {
         user: {

--- a/src/apis/children/children.service.ts
+++ b/src/apis/children/children.service.ts
@@ -11,7 +11,7 @@ export class ChildrenService {
     private childrenRepository: Repository<Children>
   ) {}
 
-  async findOneById({ childrenId }) {
+  async findOneById({ childrenId }: { childrenId: string }) {
     const children = await this.childrenRepository.findOne({
       where: { id: childrenId },
       relations: ['user'],
@@ -23,7 +23,7 @@ export class ChildrenService {
     return children;
   }
 
-  async findAllByParentsUserId({ parentsUserId }) {
+  async findAllByParentsUserId({ parentsUserId }: { parentsUserId: string }) {
     return await this.childrenRepository.find({
       where: {
         user: {

--- a/src/apis/children/interfaces/children.interface.ts
+++ b/src/apis/children/interfaces/children.interface.ts
@@ -1,4 +1,12 @@
+import { PickType } from '@nestjs/swagger';
+import { Children } from '../entities/children.entity';
+
 export interface IChildrenAddChildren {
   childrenBirths: string[];
   userId: string;
 }
+
+export class FetchAllChildrenReturn extends PickType(Children, [
+  'id',
+  'birth',
+] as const) {}


### PR DESCRIPTION
## What is the current behavior?
<!-- 수정하는 부분에 대한 설명과 (있는 경우) 연관된 이슈를 달아주세요 -->
Issue Number: #16 #35 

## What is the new behavior?
부모회원ID 값을 기반으로 내 아이 모두 찾기 API 

## 기타
원활한 코드 리뷰를 위해 간단한 변경 사항 설명을 덧붙여주시면 좋습니다.
- 돌봄 신청 시, 어떤 아이를 돌봄 신청할지 childrenId 값을 넣어줘야하므로 부모 회원 ID 값을 기반으로 아이 정보를 찾을 수 있다.
- 아이의 생년월일 순으로 조회 됩니다.