### PR TITLE
[BE-47] Refactor: 지역 추천 시니어시터 조회와 지역 전체 시니어 시터 목록 조회 API의 동일한 로직 반복 개선

### DIFF
--- a/src/apis/users/interfaces/users.interface.ts
+++ b/src/apis/users/interfaces/users.interface.ts
@@ -1,6 +1,11 @@
 import { ApiProperty, PickType, OmitType } from '@nestjs/swagger';
 import { User } from '../entities/user.entity';
 
+export class IUsersServiceSitterFindByParentsUserId {
+  parentsUserId: string;
+  returnCount?: number;
+}
+
 export class CreateParentsUsers extends PickType(User, [
   'id',
   'name',
@@ -70,3 +75,5 @@ export class FetchUserReturn extends OmitType(CreateParentsUsers, [
 }
 
 export class FetchSitterUsersReturn extends fetchBestSitterUserReturn {}
+
+export class IUsersServiceSitterFindByParentsUserIdReturn extends fetchBestSitterUserReturn {}

--- a/src/apis/users/users.controller.ts
+++ b/src/apis/users/users.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { CreateParentsDto } from './dto/createParents.dto';
 import { UsersService } from './users.service';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import {
   CreateParentsUsers,
   CreateSitterUsers,
@@ -55,7 +55,10 @@ export class UsersController {
   @Get('/sitters/:parentsUserId')
   @ApiOperation({
     summary: '지역 추천 시니어 시터 조회 API',
+    description:
+      'returnCount에 3 입력하면, 지역 추천 3명의 시니어시터 조회 가능',
   })
+  @ApiQuery({ name: 'returnCount', required: false, type: Number })
   @ApiResponse({
     status: 200,
     description: '조회 성공',
@@ -66,17 +69,22 @@ export class UsersController {
     description: '조회 실패',
   })
   fetchBestSitterUser(
-    @Param('parentsUserId') parentsUserId: string
+    @Param('parentsUserId') parentsUserId: string,
+    @Query('returnCount') returnCount: number
   ): Promise<fetchBestSitterUserReturn[]> {
-    return this.usersService.bestSitterFindAllByParentsUserId({
+    return this.usersService.sitterFindByParentsUserId({
       parentsUserId,
+      returnCount,
     });
   }
 
   @Get('/sitters/all/:parentsUserId')
   @ApiOperation({
     summary: '지역 전체 시니어 시터 목록 조회 API',
+    description:
+      'returnCount을 입력하지 않으면, 지역 전체 시니어시터 조회 가능',
   })
+  @ApiQuery({ name: 'returnCount', required: false, type: Number })
   @ApiResponse({
     status: 200,
     description: '조회 성공',
@@ -87,9 +95,13 @@ export class UsersController {
     description: '조회 실패',
   })
   fetchSitterUsers(
-    @Param('parentsUserId') parentsUserId: string
+    @Param('parentsUserId') parentsUserId: string,
+    @Query('returnCount') returnCount: number
   ): Promise<FetchSitterUsersReturn[]> {
-    return this.usersService.sitterFindAll({ parentsUserId });
+    return this.usersService.sitterFindByParentsUserId({
+      parentsUserId,
+      returnCount,
+    });
   }
 
   @Post('parents')

--- a/src/apis/users/users.service.ts
+++ b/src/apis/users/users.service.ts
@@ -85,6 +85,61 @@ export class UsersService {
     return result;
   }
 
+  async sitterFindByParentsUserId({ parentsUserId, returnCount }) {
+    const parentsUser = await this.parentsUserFindOneById({ parentsUserId });
+
+    if (!parentsUser || parentsUser.userType !== 'PARENTS') {
+      throw new UnprocessableEntityException('부모 유저를 찾을 수 없습니다.');
+    }
+
+    const wantedGuId = parentsUser.wantedGues[0].id;
+
+    const wantedGu = await this.wantedGuService.findOneByWantedGuId({
+      wantedGuId,
+    });
+
+    if (!wantedGu) {
+      throw new UnprocessableEntityException('원하는 구를 찾을 수 없습니다.');
+    }
+
+    const sitterUsers = await this.usersRepository
+      .createQueryBuilder('user')
+      .leftJoin('user.wantedGues', 'wantedGu')
+      .leftJoinAndSelect('user.careTypes', 'careType')
+      .leftJoinAndSelect('user.userChildTypes', 'userChildType')
+      .leftJoinAndSelect('userChildType.childTypes', 'childType')
+      .where('user.userType = :userType', { userType: 'SITTER' })
+      .andWhere('wantedGu.gu = :gu', { gu: wantedGu.gu.id })
+      .orderBy('user.createdAt', 'ASC')
+      .take(returnCount || 0)
+      .getMany();
+
+    const sitterUserIds = sitterUsers.map((sitterUser) => {
+      const sitterUserInfo = {
+        sitterUserId: sitterUser.id,
+        sitterUserName: sitterUser.name,
+        sitterUserCreatedAt: sitterUser.createdAt,
+        sitterUserCareType: sitterUser.careTypes,
+        sitterUserChildType: sitterUser.userChildTypes,
+      };
+      return sitterUserInfo;
+    });
+
+    const result = sitterUserIds.map((el) => ({
+      sitterUserId: el.sitterUserId,
+      sitterUserName: el.sitterUserName,
+      sitterUserCreatedAt: el.sitterUserCreatedAt,
+      sitterUserCareTypeNames: el.sitterUserCareType.map(
+        (careType) => careType.name
+      ),
+      sitterUserChildTypeNames: el.sitterUserChildType.map(
+        (childType) => childType.childTypes.name
+      ),
+    }));
+
+    return result;
+  }
+
   async bestSitterFindAllByParentsUserId({
     parentsUserId,
   }: {

--- a/src/apis/users/users.service.ts
+++ b/src/apis/users/users.service.ts
@@ -14,7 +14,11 @@ import { WantedGuService } from '../wantedGu/watnedGu.service';
 import { CareTypesService } from '../careType/careTypes.service';
 import { CHILD_TYPE_ENUM } from './types/child.type';
 import { UserChildTypesService } from '../userChildType/userChileTypes.service';
-import { FetchUserPhoneNumReturn } from './interfaces/users.interface';
+import {
+  FetchUserPhoneNumReturn,
+  IUsersServiceSitterFindByParentsUserId,
+  IUsersServiceSitterFindByParentsUserIdReturn,
+} from './interfaces/users.interface';
 
 @Injectable()
 export class UsersService {
@@ -81,7 +85,12 @@ export class UsersService {
     return result;
   }
 
-  async sitterFindByParentsUserId({ parentsUserId, returnCount }) {
+  async sitterFindByParentsUserId({
+    parentsUserId,
+    returnCount,
+  }: IUsersServiceSitterFindByParentsUserId): Promise<
+    IUsersServiceSitterFindByParentsUserIdReturn[]
+  > {
     const parentsUser = await this.parentsUserFindOneById({ parentsUserId });
 
     if (!parentsUser || parentsUser.userType !== 'PARENTS') {

--- a/src/apis/users/users.service.ts
+++ b/src/apis/users/users.service.ts
@@ -14,11 +14,7 @@ import { WantedGuService } from '../wantedGu/watnedGu.service';
 import { CareTypesService } from '../careType/careTypes.service';
 import { CHILD_TYPE_ENUM } from './types/child.type';
 import { UserChildTypesService } from '../userChildType/userChileTypes.service';
-import {
-  FetchSitterUsersReturn,
-  FetchUserPhoneNumReturn,
-  fetchBestSitterUserReturn,
-} from './interfaces/users.interface';
+import { FetchUserPhoneNumReturn } from './interfaces/users.interface';
 
 @Injectable()
 export class UsersService {
@@ -112,119 +108,6 @@ export class UsersService {
       .andWhere('wantedGu.gu = :gu', { gu: wantedGu.gu.id })
       .orderBy('user.createdAt', 'ASC')
       .take(returnCount || 0)
-      .getMany();
-
-    const sitterUserIds = sitterUsers.map((sitterUser) => {
-      const sitterUserInfo = {
-        sitterUserId: sitterUser.id,
-        sitterUserName: sitterUser.name,
-        sitterUserCreatedAt: sitterUser.createdAt,
-        sitterUserCareType: sitterUser.careTypes,
-        sitterUserChildType: sitterUser.userChildTypes,
-      };
-      return sitterUserInfo;
-    });
-
-    const result = sitterUserIds.map((el) => ({
-      sitterUserId: el.sitterUserId,
-      sitterUserName: el.sitterUserName,
-      sitterUserCreatedAt: el.sitterUserCreatedAt,
-      sitterUserCareTypeNames: el.sitterUserCareType.map(
-        (careType) => careType.name
-      ),
-      sitterUserChildTypeNames: el.sitterUserChildType.map(
-        (childType) => childType.childTypes.name
-      ),
-    }));
-
-    return result;
-  }
-
-  async bestSitterFindAllByParentsUserId({
-    parentsUserId,
-  }: {
-    parentsUserId: string;
-  }): Promise<fetchBestSitterUserReturn[]> {
-    const parentsUser = await this.parentsUserFindOneById({ parentsUserId });
-
-    if (!parentsUser || parentsUser.userType !== 'PARENTS')
-      throw new UnprocessableEntityException('부모 유저를 찾을 수 없습니다.');
-
-    const wantedGuId = parentsUser.wantedGues[0].id;
-
-    const wantedGu = await this.wantedGuService.findOneByWantedGuId({
-      wantedGuId,
-    });
-
-    if (!wantedGu)
-      throw new UnprocessableEntityException('원하는 구를 찾을 수 없습니다.');
-
-    const sitterUsers = await this.usersRepository
-      .createQueryBuilder('user')
-      .leftJoin('user.wantedGues', 'wantedGu')
-      .leftJoinAndSelect('user.careTypes', 'careType')
-      .leftJoinAndSelect('user.userChildTypes', 'userChildType')
-      .leftJoinAndSelect('userChildType.childTypes', 'childType')
-      .where('user.userType = :userType', { userType: 'SITTER' })
-      .andWhere('wantedGu.gu = :gu', { gu: wantedGu.gu.id })
-      .orderBy('user.createdAt', 'ASC')
-      .take(3)
-      .getMany();
-
-    const sitterUserIds = sitterUsers.map((sitterUser) => {
-      const sitterUserInfo = {
-        sitterUserId: sitterUser.id,
-        sitterUserName: sitterUser.name,
-        sitterUserCreatedAt: sitterUser.createdAt,
-        sitterUserCareType: sitterUser.careTypes,
-        sitterUserChildType: sitterUser.userChildTypes,
-      };
-      return sitterUserInfo;
-    });
-
-    const result = sitterUserIds.map((el) => ({
-      sitterUserId: el.sitterUserId,
-      sitterUserName: el.sitterUserName,
-      sitterUserCreatedAt: el.sitterUserCreatedAt,
-      sitterUserCareTypeNames: el.sitterUserCareType.map(
-        (careType) => careType.name
-      ),
-      sitterUserChildTypeNames: el.sitterUserChildType.map(
-        (childType) => childType.childTypes.name
-      ),
-    }));
-
-    return result;
-  }
-
-  async sitterFindAll({
-    parentsUserId,
-  }: {
-    parentsUserId: string;
-  }): Promise<FetchSitterUsersReturn[]> {
-    const parentsUser = await this.parentsUserFindOneById({ parentsUserId });
-
-    if (!parentsUser || parentsUser.userType !== 'PARENTS')
-      throw new UnprocessableEntityException('부모 유저를 찾을 수 없습니다.');
-
-    const wantedGuId = parentsUser.wantedGues[0].id;
-
-    const wantedGu = await this.wantedGuService.findOneByWantedGuId({
-      wantedGuId,
-    });
-
-    if (!wantedGu)
-      throw new UnprocessableEntityException('원하는 구를 찾을 수 없습니다.');
-
-    const sitterUsers = await this.usersRepository
-      .createQueryBuilder('user')
-      .leftJoin('user.wantedGues', 'wantedGu')
-      .leftJoinAndSelect('user.careTypes', 'careType')
-      .leftJoinAndSelect('user.userChildTypes', 'userChildType')
-      .leftJoinAndSelect('userChildType.childTypes', 'childType')
-      .where('user.userType = :userType', { userType: 'SITTER' })
-      .andWhere('wantedGu.gu = :gu', { gu: wantedGu.gu.id })
-      .orderBy('user.createdAt', 'ASC')
       .getMany();
 
     const sitterUserIds = sitterUsers.map((sitterUser) => {


### PR DESCRIPTION
## What is the current behavior?
<!-- 수정하는 부분에 대한 설명과 (있는 경우) 연관된 이슈를 달아주세요 -->
Issue Number: #27 #41 

## What is the new behavior?
지역 추천 시니어시터 조회와 지역 전체 시니어 시터 목록 조회 API가 동일한 서비스 로직으로 구성되어 있고
리턴되는 갯수만 다른 것이므로 두 로직을 합치고 return 갯수 input을 추가하여 효율성을 높였다.

## 기타
- input 값이 추가 되었습니다.
- return 되는 값이 달라지는것은 없습니다.
