### PR TITLE
[BE-54] 지역 전체 부모 목록 조회 API

### DIFF
--- a/src/apis/users/interfaces/users.interface.ts
+++ b/src/apis/users/interfaces/users.interface.ts
@@ -107,3 +107,7 @@ export class FetchNearbyJobsReturn {
   })
   parentsUserCareTypeNames: string[];
 }
+
+export class IUsersServiceParentsFindBySitterUserIdReturn extends FetchNearbyJobsReturn {}
+
+export class FetchParentsUsersReturn extends FetchNearbyJobsReturn {}

--- a/src/apis/users/users.controller.ts
+++ b/src/apis/users/users.controller.ts
@@ -6,6 +6,7 @@ import {
   CreateParentsUsers,
   CreateSitterUsers,
   FetchNearbyJobsReturn,
+  FetchParentsUsersReturn,
   FetchSitterUsersReturn,
   FetchUserPhoneNumReturn,
   FetchUserReturn,
@@ -139,7 +140,7 @@ export class UsersController {
   @ApiResponse({
     status: 200,
     description: '조회 성공',
-    // type:
+    type: FetchParentsUsersReturn,
   })
   @ApiResponse({
     status: 422,
@@ -148,7 +149,7 @@ export class UsersController {
   fetchParentsUsers(
     @Param('sitterUserId') sitterUserId: string,
     @Query('returnCount') returnCount: number
-  ) {
+  ): Promise<FetchParentsUsersReturn[]> {
     return this.usersService.parentsFindBySitterUserId({
       sitterUserId,
       returnCount,

--- a/src/apis/users/users.controller.ts
+++ b/src/apis/users/users.controller.ts
@@ -130,6 +130,31 @@ export class UsersController {
     });
   }
 
+  @Get('/parents/all/:sitterUserId')
+  @ApiOperation({
+    summary: '지역 전체 부모 목록 조회 API',
+    description: 'returnCount을 입력하지 않으면, 지역 전체 부모 조회 가능',
+  })
+  @ApiQuery({ name: 'returnCount', required: false, type: Number })
+  @ApiResponse({
+    status: 200,
+    description: '조회 성공',
+    // type:
+  })
+  @ApiResponse({
+    status: 422,
+    description: '조회 실패',
+  })
+  fetchParentsUsers(
+    @Param('sitterUserId') sitterUserId: string,
+    @Query('returnCount') returnCount: number
+  ) {
+    return this.usersService.parentsFindBySitterUserId({
+      sitterUserId,
+      returnCount,
+    });
+  }
+
   @Post('parents')
   @ApiOperation({
     summary: '부모 유저 생성 API',

--- a/src/apis/users/users.service.ts
+++ b/src/apis/users/users.service.ts
@@ -15,9 +15,9 @@ import { CareTypesService } from '../careType/careTypes.service';
 import { CHILD_TYPE_ENUM } from './types/child.type';
 import { UserChildTypesService } from '../userChildType/userChileTypes.service';
 import {
-  FetchNearbyJobsReturn,
   FetchUserPhoneNumReturn,
   IUsersServiceParentsFindBySitterUserId,
+  IUsersServiceParentsFindBySitterUserIdReturn,
   IUsersServiceSitterFindByParentsUserId,
   IUsersServiceSitterFindByParentsUserIdReturn,
 } from './interfaces/users.interface';
@@ -150,7 +150,9 @@ export class UsersService {
   async parentsFindBySitterUserId({
     sitterUserId,
     returnCount,
-  }: IUsersServiceParentsFindBySitterUserId): Promise<FetchNearbyJobsReturn[]> {
+  }: IUsersServiceParentsFindBySitterUserId): Promise<
+    IUsersServiceParentsFindBySitterUserIdReturn[]
+  > {
     const sitterUser = await this.sitterUserFindOneById({ sitterUserId });
 
     if (!sitterUser || sitterUser.userType !== 'SITTER') {


### PR DESCRIPTION
## What is the current behavior?
<!-- 수정하는 부분에 대한 설명과 (있는 경우) 연관된 이슈를 달아주세요 -->
Issue Number: #54 

## What is the new behavior?
시니어시터가 설정한 지역 내 전체 부모를 가입 순으로 조회 가능하다.

## 기타

