### PR TITLE
[BE-72] 돌봄 받은 내역 목록 조회 API 수정

### DIFF
--- a/src/apis/cares/care.service.ts
+++ b/src/apis/cares/care.service.ts
@@ -11,6 +11,7 @@ import {
 } from './interfaces/cares.interface';
 import { Care } from './entities/care.entity';
 import { ProfilesService } from '../profiles/profiles.service';
+import { USER_TYPE_ENUM } from './types/user.type';
 
 @Injectable()
 export class CaresService {
@@ -103,6 +104,7 @@ export class CaresService {
         children,
         parentsUser,
         sitterUser,
+        whoApplied: USER_TYPE_ENUM.PARENTS,
       });
     } else {
       throw new UnprocessableEntityException(
@@ -165,6 +167,7 @@ export class CaresService {
         children: parentsUserChildren[0].id,
         sitterUser,
         parentsUser,
+        whoApplied: USER_TYPE_ENUM.SITTER,
       });
     } else {
       throw new UnprocessableEntityException(

--- a/src/apis/cares/care.service.ts
+++ b/src/apis/cares/care.service.ts
@@ -37,6 +37,7 @@ export class CaresService {
           id: parentsUserId,
         },
         careStatus: STATUS_TYPE_ENUM.COMPLETE,
+        whoApplied: USER_TYPE_ENUM.PARENTS,
       },
       relations: ['sitterUser', 'parentsUser', 'children'],
       order: {

--- a/src/apis/cares/entities/care.entity.ts
+++ b/src/apis/cares/entities/care.entity.ts
@@ -11,6 +11,7 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
 } from 'typeorm';
+import { USER_TYPE_ENUM } from '../types/user.type';
 
 @Entity()
 export class Care {
@@ -21,6 +22,16 @@ export class Care {
   @IsUUID()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @ApiProperty({
+    example: 'PARENTS',
+    type: 'enum',
+    required: true,
+  })
+  @IsEnum(USER_TYPE_ENUM)
+  @IsNotEmpty()
+  @Column({ type: 'enum', enum: USER_TYPE_ENUM })
+  whoApplied: USER_TYPE_ENUM;
 
   @ApiProperty({
     example: '2023-07-28',

--- a/src/apis/cares/types/user.type.ts
+++ b/src/apis/cares/types/user.type.ts
@@ -1,0 +1,4 @@
+export enum USER_TYPE_ENUM {
+  PARENTS = 'PARENTS',
+  SITTER = 'SITTER',
+}


### PR DESCRIPTION
## What is the current behavior?
<!-- 수정하는 부분에 대한 설명과 (있는 경우) 연관된 이슈를 달아주세요 -->
Issue Number: #67 

## What is the new behavior?
부모 마이페이지에서 돌봄 받은 내역(부모가 신청한 내역)을 최신순으로 3개씩 조회할 수 있어야한다.
- 부모가 신청한 내역만 조회되어야 하는데, 시니어가 신청한 내역도 같이 조회되는 버그 수정

## 기타
- 돌봄 신청시, 누가 신청했는지 저장하는 로직 추가
- 돌봄 받은 내역 목록 조회시, 누가 신청했는지를 필터링을 걸어 조회 가능하도록 로직 수정
