### PR TITLE
[BE-70] Feat: 돌봄 받은 내역 목록 조회 API (시터님이 신청한 내역)

### DIFF
--- a/src/apis/cares/care.controller.ts
+++ b/src/apis/cares/care.controller.ts
@@ -25,7 +25,7 @@ export class CaresController {
 
   @Get('/parents/careReceived/:parentsUserId')
   @ApiOperation({
-    summary: '돌봄 받은 내역 목록 조회',
+    summary: '돌봄 받은 내역 목록 조회(부모가 신청한 내역 조회)',
     description: 'returnCount에 3 입력하면, 최신순으로 3개 조회',
   })
   @ApiQuery({ name: 'returnCount', required: false, type: Number })
@@ -43,6 +43,28 @@ export class CaresController {
     @Query('returnCount') returnCount: number
   ): Promise<GetCareReceivedReturn[]> {
     return this.careservice.getCareReceived({ parentsUserId, returnCount });
+  }
+
+  @Get('/parents/careRequested/:parentsUserId')
+  @ApiOperation({
+    summary: '돌봄 받은 내역 목록 조회(시터님이 신청한 내역 조회)',
+    description: 'returnCount에 3 입력하면, 최신순으로 3개 조회',
+  })
+  @ApiQuery({ name: 'returnCount', required: false, type: Number })
+  @ApiResponse({
+    status: 200,
+    description: '조회 성공',
+    type: [GetCareReceivedReturn],
+  })
+  @ApiResponse({
+    status: 422,
+    description: '조회 실패',
+  })
+  getCareRequested(
+    @Param('parentsUserId') parentsUserId: string,
+    @Query('returnCount') returnCount: number
+  ): Promise<GetCareReceivedReturn[]> {
+    return this.careservice.getCareRequested({ parentsUserId, returnCount });
   }
 
   @Post('/parents/:parentsUserId')

--- a/src/apis/cares/care.controller.ts
+++ b/src/apis/cares/care.controller.ts
@@ -17,6 +17,7 @@ import {
 import {
   CreateCareReturn,
   GetCareReceivedReturn,
+  GetCareRequestedReturn,
 } from './interfaces/cares.interface';
 
 @Controller('cares')
@@ -54,7 +55,7 @@ export class CaresController {
   @ApiResponse({
     status: 200,
     description: '조회 성공',
-    type: [GetCareReceivedReturn],
+    type: [GetCareRequestedReturn],
   })
   @ApiResponse({
     status: 422,
@@ -63,7 +64,7 @@ export class CaresController {
   getCareRequested(
     @Param('parentsUserId') parentsUserId: string,
     @Query('returnCount') returnCount: number
-  ): Promise<GetCareReceivedReturn[]> {
+  ): Promise<GetCareRequestedReturn[]> {
     return this.careservice.getCareRequested({ parentsUserId, returnCount });
   }
 

--- a/src/apis/cares/care.service.ts
+++ b/src/apis/cares/care.service.ts
@@ -7,7 +7,9 @@ import { STATUS_TYPE_ENUM } from './types/status.type';
 import {
   CreateCareReturn,
   GetCareReceivedReturn,
+  GetCareRequestedReturn,
   ICareServiceGetCareReceived,
+  ICareServiceGetCareRequested,
 } from './interfaces/cares.interface';
 import { Care } from './entities/care.entity';
 import { ProfilesService } from '../profiles/profiles.service';
@@ -47,6 +49,40 @@ export class CaresService {
     });
 
     const result = caresRecevied.map((careRecevied) => ({
+      careId: careRecevied.id,
+      allCounting: parentsUserProfile.careCounting,
+      sitterName: careRecevied.sitterUser.name,
+      date: careRecevied.date,
+      startTime: careRecevied.startTime,
+      endTime: careRecevied.endTime,
+    }));
+
+    return result;
+  }
+
+  async getCareRequested({
+    parentsUserId,
+    returnCount,
+  }: ICareServiceGetCareRequested): Promise<GetCareRequestedReturn[]> {
+    const parentsUserProfile =
+      await this.profilesService.findOneByParentsUserId({ parentsUserId });
+
+    const caresRequested = await this.caresRepository.find({
+      where: {
+        parentsUser: {
+          id: parentsUserId,
+        },
+        careStatus: STATUS_TYPE_ENUM.COMPLETE,
+        whoApplied: USER_TYPE_ENUM.SITTER,
+      },
+      relations: ['sitterUser', 'parentsUser', 'children'],
+      order: {
+        date: 'DESC',
+      },
+      take: returnCount || undefined,
+    });
+
+    const result = caresRequested.map((careRecevied) => ({
       careId: careRecevied.id,
       allCounting: parentsUserProfile.careCounting,
       sitterName: careRecevied.sitterUser.name,

--- a/src/apis/cares/interfaces/cares.interface.ts
+++ b/src/apis/cares/interfaces/cares.interface.ts
@@ -16,6 +16,8 @@ export class ICareServiceGetCareReceived {
   returnCount?: number;
 }
 
+export class ICareServiceGetCareRequested extends ICareServiceGetCareReceived {}
+
 export class CreateCareReturn {
   @ApiProperty({
     example: 'c4b5617e-f8ce-4650-b50a-bb7e09b75ef2',
@@ -63,3 +65,5 @@ export class GetCareReceivedReturn extends PickType(CreateCareReturn, [
   })
   sitterName: string;
 }
+
+export class GetCareRequestedReturn extends GetCareReceivedReturn {}


### PR DESCRIPTION
## What is the current behavior?
<!-- 수정하는 부분에 대한 설명과 (있는 경우) 연관된 이슈를 달아주세요 -->
Issue Number: 

## What is the new behavior?
부모 마이페이지의 돌봄받은 내역에서 시터님이 신청한 돌봄 내역 최신순 3개 목록 조회가 가능하다.

## 기타
원활한 코드 리뷰를 위해 간단한 변경 사항 설명을 덧붙여주시면 좋습니다.
