### PR TITLE
[BE-78] 돌봄한 내역 목록 조회 API (부모가 신청한 내역) 

### DIFF
--- a/src/apis/cares/care.controller.ts
+++ b/src/apis/cares/care.controller.ts
@@ -93,6 +93,31 @@ export class CaresController {
     return this.careservice.getCareRequested({ sitterUserId, returnCount });
   }
 
+  @Get('/sitter/careRequestedByParents/:sitterUserId')
+  @ApiOperation({
+    summary: '돌봄 한 내역 목록 조회(부모가 신청한 내역 조회)',
+    description: 'returnCount에 3 입력하면, 최신순으로 3개 조회',
+  })
+  @ApiQuery({ name: 'returnCount', required: false, type: Number })
+  @ApiResponse({
+    status: 200,
+    description: '조회 성공',
+    type: [GetCareRequestedReturn],
+  })
+  @ApiResponse({
+    status: 422,
+    description: '조회 실패',
+  })
+  getCareRequestedByParents(
+    @Param('sitterUserId') sitterUserId: string,
+    @Query('returnCount') returnCount: number
+  ): Promise<GetCareRequestedReturn[]> {
+    return this.careservice.getCareRequestedByParents({
+      sitterUserId,
+      returnCount,
+    });
+  }
+
   @Get('/parents/careReceived/all/:parentsUserId')
   @ApiOperation({
     summary: '돌봄 받은 내역 전체 목록 조회(부모가 신청한 내역 조회)',


### PR DESCRIPTION
## What is the current behavior?
<!-- 수정하는 부분에 대한 설명과 (있는 경우) 연관된 이슈를 달아주세요 -->
Issue Number: N/A

## What is the new behavior?
시터 마이페이지에서 돌봄한 내역(부모가 신청한 내역)을 최신순으로 3개씩 조회할 수 있다.

## 기타

