### PR TITLE
[BE-79] Feat: 돌봄 한 내역 전체 목록 조회(시터가 신청한 내역 조회) API

### DIFF
--- a/src/apis/cares/care.controller.ts
+++ b/src/apis/cares/care.controller.ts
@@ -165,6 +165,28 @@ export class CaresController {
     });
   }
 
+  @Get('/sitter/careRequested/all/:sitterUserId')
+  @ApiOperation({
+    summary: '돌봄 한 내역 전체 목록 조회(시터가 신청한 내역 조회)',
+    description: 'returnCount을 입력하지 않으면, 최신순으로 전체 조회 가능',
+  })
+  @ApiQuery({ name: 'returnCount', required: false, type: Number })
+  @ApiResponse({
+    status: 200,
+    description: '조회 성공',
+    type: [GetCareRequestedReturn],
+  })
+  @ApiResponse({
+    status: 422,
+    description: '조회 실패',
+  })
+  getCareRequestedAll(
+    @Param('sitterUserId') sitterUserId: string,
+    @Query('returnCount') returnCount: number
+  ): Promise<GetCareRequestedReturn[]> {
+    return this.careservice.getCareRequested({ sitterUserId, returnCount });
+  }
+
   @Post('/parents/:parentsUserId')
   @ApiOperation({
     summary: '부모 유저가 신청하는 돌봄 신청 API',


### PR DESCRIPTION
## What is the current behavior?
<!-- 수정하는 부분에 대한 설명과 (있는 경우) 연관된 이슈를 달아주세요 -->
Issue Number: N/A

## What is the new behavior?
시터 마이페이지에서 돌봄한 내역(시터입장에서 내가 신청한 내역)을 전체 조회할 수 있다.

## 기타

